### PR TITLE
商品の状態、ユーザーの状態によって商品詳細ページの表示を変える

### DIFF
--- a/app/assets/stylesheets/_home.scss
+++ b/app/assets/stylesheets/_home.scss
@@ -107,6 +107,12 @@ main{
             width: 100%;
             height: 100%;
           }
+          .item-sold-label{
+            @include sold-label;
+          }
+          .item-sold-label-text{
+            @include sold-label-text;
+          }
           span{
             position: absolute;
             bottom:20px;
@@ -119,7 +125,6 @@ main{
             background: rgba(0,0,0,.4);
             padding: 3px 12px;
             border-radius: 0 90px 90px 0;
-  
           }
         }
 

--- a/app/assets/stylesheets/_items.scss
+++ b/app/assets/stylesheets/_items.scss
@@ -116,6 +116,9 @@ li{
     &__tax{
       font-size:10px;
     }
+    .item-show-nobtn{
+      height: 30px;
+    }
     .item-sold-out{
       background: #888;
       margin-bottom: 30px;

--- a/app/assets/stylesheets/_items.scss
+++ b/app/assets/stylesheets/_items.scss
@@ -47,7 +47,16 @@ li{
         max-width: 300px;
         min-height: 395px;  
         background-color: #f5f5f5;
-   
+        .item-sold-label{
+          @include sold-label;
+          border-bottom: 120px solid transparent;
+          border-left: 120px solid $color-red;
+        }
+        .item-sold-label-text{
+          @include sold-label-text;
+          font-size: 30px;
+          top: 25px;
+        }
       }
     }
 
@@ -106,6 +115,10 @@ li{
     }
     &__tax{
       font-size:10px;
+    }
+    .item-sold-out{
+      background: #888;
+      margin-bottom: 30px;
     }
   }
 

--- a/app/assets/stylesheets/mixin/_mixin-label.scss
+++ b/app/assets/stylesheets/mixin/_mixin-label.scss
@@ -30,4 +30,23 @@
   font-size: 12px;
   text-align: center;
 }
+@mixin sold-label(){
+  content: "";
+  border-bottom: 75px solid transparent;
+  border-left: 75px solid $color-red;
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 100;
+}
+@mixin sold-label-text{
+  display: block;
+  top: 20px;
+  transform: rotate(-45deg);
+  color: #fff;
+  font-weight: bold;
+  position: absolute;
+  left: 2;
+  z-index: 101;
+}
 

--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -26,7 +26,12 @@ class PurchaseController < ApplicationController
   end
 
   def done #購入完了ページ
-    @item.update(buyer_id: current_user.id)
+    if @item.update(buyer_id: current_user.id)
+      notice: '購入が完了しました'
+    else
+      redirect_to root_path,alert: '購入できませんでした。'
+    end
+
   end
 
 

--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -5,16 +5,16 @@ class PurchaseController < ApplicationController
 
   
   def index
-    if @card.blank? #登録された情報がない場合にカード登録画面に移動
-      redirect_to controller: "card", action: "new"
+    if @card.blank? 
+      redirect_to controller: "card", action: "new" #登録された情報がない場合にカード登録画面に移動
     else
-      Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]#保管した顧客IDでpayjpから情報取得
+      Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"] #保管した顧客IDでpayjpから情報取得
       customer = Payjp::Customer.retrieve(@card.customer_id)
-      @default_card_information = customer.cards.retrieve(@card.card_id)#保管したカードIDでpayjpから情報取得、カード情報表示のためインスタンス変数に代入
+      @default_card_information = customer.cards.retrieve(@card.card_id) #保管したカードIDでpayjpから情報取得、カード情報表示のためインスタンス変数に代入
     end
   end
 
-  def pay
+  def pay #payjpを使って商品購入
     Payjp.api_key = ENV['PAYJP_PRIVATE_KEY']
     Payjp::Charge.create(
     amount: @item.price, #支払金額を入力
@@ -25,8 +25,8 @@ class PurchaseController < ApplicationController
   redirect_to done_purchase_index_path(@item.id) #完了画面に移動
   end
 
-  def done
-    @item.updete(bayer_id: current_user.id)
+  def done #購入完了ページ
+    @item.update(buyer_id: current_user.id)
   end
 
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -9,6 +9,10 @@ class Item < ApplicationRecord
   has_many :regions
   accepts_nested_attributes_for :regions
 
+  #userテーブルの「id」とitemsテーブルの「buyer_id」「saler_id」を紐付ける
+  belongs_to :seller, class_name: "User"
+  belongs_to :buyer, class_name: "User"
+
   validates :seller_id,{presence:true}
 
   def seller
@@ -22,7 +26,6 @@ class Item < ApplicationRecord
   def next
     Item.where("id > ?", id).order("id ASC").first
   end
-
 
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to_active_hash :prefecture

--- a/app/views/card/index.html.haml
+++ b/app/views/card/index.html.haml
@@ -1,7 +1,5 @@
 = render 'shared/header', header: @header
-= link_to exhibit_index_path, class: "cam-icon" do
-  %p 出品
-  %i.fas.fa-camera.fa-4x
+= render 'layouts/exhibit-button'
 
 .mypage-container
   = render 'shared/mypage-side'

--- a/app/views/card/new.html.haml
+++ b/app/views/card/new.html.haml
@@ -1,7 +1,5 @@
 = render 'shared/header', header: @header
-= link_to exhibit_index_path, class: "cam-icon" do
-  %p 出品
-  %i.fas.fa-camera.fa-4x
+= render 'layouts/exhibit-button'
 
 .mypage-container
   = render 'shared/mypage-side'

--- a/app/views/card/show.html.haml
+++ b/app/views/card/show.html.haml
@@ -1,7 +1,5 @@
 = render 'shared/header', header: @header
-= link_to exhibit_index_path, class: "cam-icon" do
-  %p 出品
-  %i.fas.fa-camera.fa-4x
+= render 'layouts/exhibit-button'
 
 .mypage-container
   = render 'shared/mypage-side'

--- a/app/views/items/_home-index.html.haml
+++ b/app/views/items/_home-index.html.haml
@@ -1,10 +1,37 @@
 - @items.each do |item|
-  = link_to item_path(item.id),class:"items-box" do
-    .items-image
-      =image_tag item.images[0].image
-      %span
-        ¥
-        = converting_to_jpy(item.price) #ヘルパーメソッド使用し区切りカンマを表示
-    .items-body
-      .items-body__name
-        = item.name
+  - if (item.buyer_id.blank?)
+    = link_to item_path(item.id),class:"items-box" do
+      .items-image
+        =image_tag item.images[0].image
+        %span
+          ¥
+          = converting_to_jpy(item.price) #ヘルパーメソッド使用し区切りカンマを表示
+      .items-body
+        .items-body__name
+          = item.name
+  - else
+    = link_to item_path(item.id),class:"items-box" do
+      .items-image
+        =image_tag item.images[0].image
+        .item-sold-label
+        .item-sold-label-text
+          SOLD
+        %span
+          ¥
+          = converting_to_jpy(item.price) #ヘルパーメソッド使用し区切りカンマを表示
+      .items-body
+        .items-body__name
+          = item.name
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -1,5 +1,4 @@
 = render 'shared/header', header: @header
-
 = render 'layouts/exhibit-button'
 %main
   .top_image

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -7,9 +7,18 @@
     .item-photo
       .item-photo__main
         %ul.slider
-          - @item.images.each do |image|
-            %li
-              = image_tag image.image
+          - if (@item.buyer_id.blank?)
+            - @item.images.each do |image|
+              %li
+                = image_tag image.image
+          - else
+            - @item.images.each do |image|
+              %li
+                = image_tag image.image
+                .item-sold-label
+                .item-sold-label-text
+                  SOLD
+
     %table.item-detail-table
       %tr
         %th 出品者
@@ -58,8 +67,21 @@
       (税込)
     %span.item-price__shipping-fee
       送料込み
-    = link_to purchase_index_path(@item.id), class: "buy-btn" do
-      購入画面に進む
+
+    -# ユーザーと商品の状態によって商品詳細ページの表示を変える
+    - if (@item.buyer_id.blank?)
+      - if user_signed_in?
+        - if @item.seller_id == current_user.id
+
+        - else
+          = link_to purchase_index_path(@item.id), class: "buy btn" do
+            購入画面に進む 
+      - else
+        = link_to signup_index_path, class: "buy btn" do
+          購入画面に進む      
+    - else
+      .item-sold-out.btn
+        売り切れました
 
   .item-description
     = simple_format(@item.detail)

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -67,12 +67,12 @@
       (税込)
     %span.item-price__shipping-fee
       送料込み
-
+      
     -# ユーザーと商品の状態によって商品詳細ページの表示を変える
     - if (@item.buyer_id.blank?)
       - if user_signed_in?
         - if @item.seller_id == current_user.id
-
+          .item-show-nobtn
         - else
           = link_to purchase_index_path(@item.id), class: "buy btn" do
             購入画面に進む 

--- a/app/views/layouts/_exhibit-button.html.haml
+++ b/app/views/layouts/_exhibit-button.html.haml
@@ -1,3 +1,8 @@
-= link_to  new_item_path, class: "cam-icon" do
-  %p 出品
-  %i.fas.fa-camera.fa-4x
+- if user_signed_in?  
+  = link_to new_item_path, class: "cam-icon" do
+    %p 出品
+    %i.fas.fa-camera.fa-4x
+- else
+  = link_to signup_index_path, class: "cam-icon" do
+    %p 出品
+    %i.fas.fa-camera.fa-4x

--- a/app/views/mypage/logout.html.haml
+++ b/app/views/mypage/logout.html.haml
@@ -1,7 +1,5 @@
 = render 'shared/header', header: @header
-= link_to exhibit_index_path, class: "cam-icon" do
-  %p 出品
-  %i.fas.fa-camera.fa-4x
+= render 'layouts/exhibit-button'
   
 .mypage-container
   = render 'shared/mypage-side'

--- a/app/views/mypage/profile.html.haml
+++ b/app/views/mypage/profile.html.haml
@@ -1,7 +1,5 @@
 = render 'shared/header', header: @header
-= link_to exhibit_index_path, class: "cam-icon" do
-  %p 出品
-  %i.fas.fa-camera.fa-4x
+= render 'layouts/exhibit-button'
 
 .mypage-container
   = render 'shared/mypage-side'


### PR DESCRIPTION
## WHAT
ユーザーの状態、商品の状態によって
商品詳細の表示とリンク先を分ける。

## WHY
ユーザー、商品の状態によって使用できる機能を分けるため。

---
実装GIF
[【ログアウト中】](https://gyazo.com/ed5f99e8c7e99129fcb1307f0254d22f)
[【ログイン中/出品中アイテム】](https://gyazo.com/2bd5b9e432b57eef73c0999c84527fbd)
[【ログイン中/SOLDアイテム】](https://gyazo.com/ea36b0daa3daf8d50233506507614c13)
[【ログイン中/ユーザー＝出品者】](https://gyazo.com/9bcc865393820f9ae91fbc902c97038a)

